### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,8 @@ jobs:
   benchmark:
     name: Performance regression check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/assemblyscript-regex/security/code-scanning/3](https://github.com/DevCycleHQ/assemblyscript-regex/security/code-scanning/3)

The best way to fix this problem is to explicitly add a `permissions` block either at the root workflow level or the job level, restricting the GITHUB_TOKEN to only required privileges. For this workflow, as most steps only check out code and run benchmarks, `contents: read` is a minimal safe permission, while additional permissions (such as `contents: write` or `pull-requests: write`) should only be added if needed by specific tools (for instance, if the benchmark comment/alert requires write access, that might need more). The recommended starting point is to add `permissions: contents: read` to the job definition in `.github/workflows/benchmark.yml` above or below the `runs-on` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
