### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/assemblyscript-regex/security/code-scanning/2](https://github.com/DevCycleHQ/assemblyscript-regex/security/code-scanning/2)

To fix the issue, explicitly set the permissions required for the workflow, ideally at the root level to ensure all jobs inherit the restriction. Since this workflow only checks out the code and runs tests, no write access is necessary, so the minimal required permissions are `contents: read`. To implement this, add a `permissions` block near the top of the file, preferably just after the `name` key and before the `on` key, as shown in the best practices examples. No new methods, definitions, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
