### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   release:
     name: Release
+    permissions:
+      contents: write
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/assemblyscript-regex/security/code-scanning/1](https://github.com/DevCycleHQ/assemblyscript-regex/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or to each job. Since CodeQL suggests starting with `contents: read`, and because the workflow runs steps related to releases that may require additional write permissions (such as creating releases or pushing tags), be as restrictive as possible but allow necessary function. The single best way to fix is to add to the `release` job (line 12), immediately before `runs-on`, the following block:

```yaml
permissions:
  contents: write
```

If more granular permissions are required (e.g., writing to releases or pull requests), you may add those. However, based on common releases via semantic-release and minimal starting point, `contents: write` is likely sufficient.

- Edit `.github/workflows/release.yml` in the job `release` (line 12), inserting the `permissions` block after the job name and before `runs-on`.
- No imports, methods, or variable changes required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
