### PR TITLE
fix: resolve open dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3442,6 +3442,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
@@ -6434,19 +6447,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -7560,6 +7560,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -10355,7 +10368,15 @@
       "dev": true,
       "requires": {
         "braces": "^3.0.3",
-        "picomatch": "4.0.4"
+        "picomatch": "^2.3.2"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+          "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+          "dev": true
+        }
       }
     },
     "mime": {
@@ -11985,7 +12006,7 @@
           "dev": true,
           "requires": {
             "fdir": "^6.5.0",
-            "picomatch": "4.0.4"
+            "picomatch": "^2.3.2"
           }
         },
         "treeverse": {
@@ -12338,12 +12359,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
-    },
-    "picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true
     },
     "pify": {
@@ -13123,7 +13138,15 @@
       "dev": true,
       "requires": {
         "fdir": "^6.5.0",
-        "picomatch": "4.0.4"
+        "picomatch": "^2.3.2"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+          "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+          "dev": true
+        }
       }
     },
     "to-regex-range": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3234,10 +3234,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.0",
@@ -6434,13 +6435,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -8200,7 +8201,7 @@
       "requires": {
         "@chevrotain/gast": "10.5.0",
         "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "@chevrotain/gast": {
@@ -8210,7 +8211,7 @@
       "dev": true,
       "requires": {
         "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "@chevrotain/types": {
@@ -8814,7 +8815,7 @@
       "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "platform": "^1.3.3"
       }
     },
@@ -8904,7 +8905,7 @@
         "@chevrotain/gast": "10.5.0",
         "@chevrotain/types": "10.5.0",
         "@chevrotain/utils": "10.5.0",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "regexp-to-ast": "0.5.0"
       }
     },
@@ -10204,9 +10205,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash-es": {
@@ -10354,7 +10355,7 @@
       "dev": true,
       "requires": {
         "braces": "^3.0.3",
-        "picomatch": "^2.3.2"
+        "picomatch": "4.0.4"
       }
     },
     "mime": {
@@ -11984,7 +11985,7 @@
           "dev": true,
           "requires": {
             "fdir": "^6.5.0",
-            "picomatch": "^2.3.2"
+            "picomatch": "4.0.4"
           }
         },
         "treeverse": {
@@ -12340,9 +12341,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true
     },
     "pify": {
@@ -13122,7 +13123,7 @@
       "dev": true,
       "requires": {
         "fdir": "^6.5.0",
-        "picomatch": "^2.3.2"
+        "picomatch": "4.0.4"
       }
     },
     "to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "overrides": {
     "handlebars": "^4.7.9",
-    "picomatch": "4.0.4",
+    "picomatch": "^2.3.2",
     "flatted": "^3.4.2",
     "glob-promise": "^6.0.7",
     "lodash": "4.18.1"

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
   },
   "overrides": {
     "handlebars": "^4.7.9",
-    "picomatch": "^2.3.2",
+    "picomatch": "4.0.4",
     "flatted": "^3.4.2",
-    "glob-promise": "^6.0.7"
+    "glob-promise": "^6.0.7",
+    "lodash": "4.18.1"
   },
   "devDependencies": {
     "@as-pect/cli": "^8.0.1",


### PR DESCRIPTION
## Summary

Resolved 3 open Dependabot security alerts by bumping vulnerable transitive dependencies via npm overrides.

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #113 | `picomatch` | **medium** | Pinned to 4.0.4 via npm overrides |
| #111 | `lodash` | **high** | Pinned to 4.18.1 via npm overrides |
| #110 | `lodash` | **medium** | Pinned to 4.18.1 via npm overrides |