### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.14.x
       - run: npm ci --legacy-peer-deps
       - run: npm run asbuild
       # Run benchmark with `go test -bench` and stores the output to a file

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci --legacy-peer-deps
       - run: npm run asbuild
       # Run benchmark with `go test -bench` and stores the output to a file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.14.x
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [22.14.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 npm-debug.*
 assembly/__tests__/index.spec.wat
 assembly/__tests__/spec.spec.wat
+.worktrees/

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ assembly/char.ts
 assembly/nfa/matcher.ts
 assembly/nfa/types.ts
 assembly/parser/walker.ts
+.worktrees/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11306,7 +11306,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip-address": ">=10.1.1",
+            "ip-address": "10.1.1",
             "smart-buffer": "^4.2.0"
           }
         },
@@ -11380,7 +11380,7 @@
           "dev": true,
           "requires": {
             "fdir": "^6.5.0",
-            "picomatch": ">=4.0.4"
+            "picomatch": "4.0.4"
           },
           "dependencies": {
             "fdir": {
@@ -11980,7 +11980,7 @@
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
         "@semantic-release/github": "^11.0.0",
-        "@semantic-release/npm": ">=13.0.0",
+        "@semantic-release/npm": "13.1.5",
         "@semantic-release/release-notes-generator": "^14.0.0-beta.1",
         "aggregate-error": "^5.0.0",
         "cosmiconfig": "^9.0.0",
@@ -12329,7 +12329,7 @@
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": ">=3.1.2",
+            "fast-uri": "3.1.2",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -12426,7 +12426,7 @@
       "dev": true,
       "requires": {
         "fdir": "^6.5.0",
-        "picomatch": ">=4.0.4"
+        "picomatch": "4.0.4"
       }
     },
     "to-regex-range": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,45 @@
         "typescript": "^4.1.3"
       }
     },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@as-covers/assembly": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@as-covers/assembly/-/assembly-0.4.1.tgz",
@@ -759,31 +798,166 @@
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.2.tgz",
-      "integrity": "sha512-+M9/Lb35IgnlUO6OSJ40Ie+hUsZLuph2fqXC/qrKn0fMvUU/jiCjpoL6zEm69vzcmaZJ8yNKtMBEKHWN49WBbQ==",
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.5.tgz",
+      "integrity": "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@actions/core": "^3.0.0",
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^5.0.0",
+        "env-ci": "^11.2.0",
         "execa": "^9.0.0",
         "fs-extra": "^11.0.0",
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^8.0.0",
-        "npm": "^10.9.3",
+        "normalize-url": "^9.0.0",
+        "npm": "^11.6.2",
         "rc": "^1.2.8",
-        "read-pkg": "^9.0.0",
+        "read-pkg": "^10.0.0",
         "registry-auth-token": "^5.0.0",
         "semver": "^7.1.2",
         "tempy": "^3.0.0"
       },
       "engines": {
-        "node": ">=20.8.1"
+        "node": "^22.14.0 || >= 24.10.0"
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/normalize-package-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+      "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/read-pkg": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+      "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.4",
+        "normalize-package-data": "^8.0.0",
+        "parse-json": "^8.3.0",
+        "type-fest": "^5.4.4",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
@@ -2383,9 +2557,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -3627,28 +3801,29 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
-      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.0.tgz",
+      "integrity": "sha512-z9nC87iaZXXySbWWtTHfCFJyFvKaUAW6lODhikG7ILSbVgmwuFjUqkgnheHvAUcGedO29e2QGBRXMUD64aurqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm": {
-      "version": "10.9.8",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.8.tgz",
-      "integrity": "sha512-fYwb6ODSmHkqrJQQaCxY3M2lPf/mpgC7ik0HSzzIwG5CGtabRp4bNqikatvCoT42b5INQSqudVH0R7yVmC9hVg==",
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
+      "integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
         "@npmcli/config",
         "@npmcli/fs",
         "@npmcli/map-workspaces",
+        "@npmcli/metavuln-calculator",
         "@npmcli/package-json",
         "@npmcli/promise-spawn",
         "@npmcli/redact",
@@ -3659,7 +3834,6 @@
         "cacache",
         "chalk",
         "ci-info",
-        "cli-columns",
         "fastest-levenshtein",
         "fs-minipass",
         "glob",
@@ -3673,7 +3847,6 @@
         "libnpmdiff",
         "libnpmexec",
         "libnpmfund",
-        "libnpmhook",
         "libnpmorg",
         "libnpmpack",
         "libnpmpublish",
@@ -3687,7 +3860,6 @@
         "ms",
         "node-gyp",
         "nopt",
-        "normalize-package-data",
         "npm-audit-report",
         "npm-install-checks",
         "npm-package-arg",
@@ -3710,8 +3882,7 @@
         "tiny-relative-date",
         "treeverse",
         "validate-npm-package-name",
-        "which",
-        "write-file-atomic"
+        "which"
       ],
       "dev": true,
       "license": "Artistic-2.0",
@@ -3724,80 +3895,77 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^8.0.5",
-        "@npmcli/config": "^9.0.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/map-workspaces": "^4.0.2",
-        "@npmcli/package-json": "^6.2.0",
-        "@npmcli/promise-spawn": "^8.0.3",
-        "@npmcli/redact": "^3.2.2",
-        "@npmcli/run-script": "^9.1.0",
-        "@sigstore/tuf": "^3.1.1",
-        "abbrev": "^3.0.1",
+        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/config": "^10.9.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/map-workspaces": "^5.0.3",
+        "@npmcli/metavuln-calculator": "^9.0.3",
+        "@npmcli/package-json": "^7.0.5",
+        "@npmcli/promise-spawn": "^9.0.1",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.4",
+        "@sigstore/tuf": "^4.0.2",
+        "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^19.0.1",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
         "ci-info": "^4.4.0",
-        "cli-columns": "^4.0.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^10.5.0",
+        "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^8.1.0",
-        "ini": "^5.0.0",
-        "init-package-json": "^7.0.2",
-        "is-cidr": "^5.1.1",
-        "json-parse-even-better-errors": "^4.0.0",
-        "libnpmaccess": "^9.0.0",
-        "libnpmdiff": "^7.0.5",
-        "libnpmexec": "^9.0.5",
-        "libnpmfund": "^6.0.5",
-        "libnpmhook": "^11.0.0",
-        "libnpmorg": "^7.0.0",
-        "libnpmpack": "^8.0.5",
-        "libnpmpublish": "^10.0.2",
-        "libnpmsearch": "^8.0.0",
-        "libnpmteam": "^7.0.0",
-        "libnpmversion": "^7.0.0",
-        "make-fetch-happen": "^14.0.3",
-        "minimatch": "^9.0.9",
+        "hosted-git-info": "^9.0.2",
+        "ini": "^6.0.0",
+        "init-package-json": "^8.2.5",
+        "is-cidr": "^6.0.4",
+        "json-parse-even-better-errors": "^5.0.0",
+        "libnpmaccess": "^10.0.3",
+        "libnpmdiff": "^8.1.7",
+        "libnpmexec": "^10.2.7",
+        "libnpmfund": "^7.0.21",
+        "libnpmorg": "^8.0.1",
+        "libnpmpack": "^9.1.7",
+        "libnpmpublish": "^11.1.3",
+        "libnpmsearch": "^9.0.1",
+        "libnpmteam": "^8.0.2",
+        "libnpmversion": "^8.0.3",
+        "make-fetch-happen": "^15.0.5",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^11.5.0",
-        "nopt": "^8.1.0",
-        "normalize-package-data": "^7.0.1",
-        "npm-audit-report": "^6.0.0",
-        "npm-install-checks": "^7.1.2",
-        "npm-package-arg": "^12.0.2",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-profile": "^11.0.1",
-        "npm-registry-fetch": "^18.0.2",
-        "npm-user-validate": "^3.0.0",
+        "node-gyp": "^12.3.0",
+        "nopt": "^9.0.0",
+        "npm-audit-report": "^7.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.2",
+        "npm-pick-manifest": "^11.0.3",
+        "npm-profile": "^12.0.1",
+        "npm-registry-fetch": "^19.1.1",
+        "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^19.0.1",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "pacote": "^21.5.0",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^4.1.0",
+        "read": "^5.0.1",
         "semver": "^7.7.4",
         "spdx-expression-parse": "^4.0.0",
-        "ssri": "^12.0.0",
-        "supports-color": "^9.4.0",
-        "tar": "^7.5.11",
+        "ssri": "^13.0.1",
+        "supports-color": "^10.2.2",
+        "tar": "^7.5.13",
         "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
+        "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^6.0.2",
-        "which": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -3830,71 +3998,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
+    "node_modules/npm/node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -3916,7 +4026,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3924,84 +4034,82 @@
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
+        "lru-cache": "^11.2.1",
         "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "8.0.5",
+      "version": "9.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/map-workspaces": "^4.0.1",
-        "@npmcli/metavuln-calculator": "^8.0.0",
-        "@npmcli/name-from-folder": "^3.0.0",
-        "@npmcli/node-gyp": "^4.0.0",
-        "@npmcli/package-json": "^6.0.1",
-        "@npmcli/query": "^4.0.0",
-        "@npmcli/redact": "^3.0.0",
-        "@npmcli/run-script": "^9.0.1",
-        "bin-links": "^5.0.0",
-        "cacache": "^19.0.1",
-        "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^8.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/metavuln-calculator": "^9.0.2",
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/query": "^5.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "bin-links": "^6.0.0",
+        "cacache": "^20.0.1",
+        "common-ancestor-path": "^2.0.0",
+        "hosted-git-info": "^9.0.0",
         "json-stringify-nice": "^1.1.4",
-        "lru-cache": "^10.2.2",
-        "minimatch": "^9.0.4",
-        "nopt": "^8.0.0",
-        "npm-install-checks": "^7.1.0",
-        "npm-package-arg": "^12.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.1",
-        "pacote": "^19.0.0",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "proggy": "^3.0.0",
+        "lru-cache": "^11.2.1",
+        "minimatch": "^10.0.3",
+        "nopt": "^9.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "pacote": "^21.0.2",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.0.0",
+        "proggy": "^4.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^3.0.1",
-        "promise-retry": "^2.0.1",
-        "read-package-json-fast": "^4.0.0",
         "semver": "^7.3.7",
-        "ssri": "^12.0.0",
+        "ssri": "^13.0.0",
         "treeverse": "^3.0.0",
-        "walk-up-path": "^3.0.1"
+        "walk-up-path": "^4.0.0"
       },
       "bin": {
         "arborist": "bin/index.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "9.0.0",
+      "version": "10.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/map-workspaces": "^4.0.1",
-        "@npmcli/package-json": "^6.0.1",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
         "ci-info": "^4.0.0",
-        "ini": "^5.0.0",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
+        "ini": "^6.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "walk-up-path": "^3.0.1"
+        "walk-up-path": "^4.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4009,156 +4117,125 @@
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "6.0.3",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/promise-spawn": "^8.0.0",
-        "ini": "^5.0.0",
-        "lru-cache": "^10.0.1",
-        "npm-pick-manifest": "^10.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
+        "lru-cache": "^11.2.1",
+        "npm-pick-manifest": "^11.0.1",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-bundled": "^4.0.0",
-        "npm-normalize-package-bin": "^4.0.0"
+        "npm-bundled": "^5.0.0",
+        "npm-normalize-package-bin": "^5.0.0"
       },
       "bin": {
         "installed-package-contents": "bin/index.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "4.0.2",
+      "version": "5.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/name-from-folder": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "glob": "^10.2.2",
-        "minimatch": "^9.0.0"
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "glob": "^13.0.0",
+        "minimatch": "^10.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "8.0.1",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cacache": "^19.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "pacote": "^20.0.0",
-        "proc-log": "^5.0.0",
+        "cacache": "^20.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "pacote": "^21.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
-      "version": "20.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "@npmcli/run-script": "^9.0.0",
-        "cacache": "^19.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^7.0.2",
-        "npm-package-arg": "^12.0.0",
-        "npm-packlist": "^9.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0",
-        "tar": "^7.5.10"
-      },
-      "bin": {
-        "pacote": "bin/index.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "6.2.0",
+      "version": "7.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "glob": "^10.2.2",
-        "hosted-git-info": "^8.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "@npmcli/git": "^7.0.0",
+        "glob": "^13.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.5.3",
-        "validate-npm-package-license": "^3.0.4"
+        "spdx-expression-parse": "^4.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "8.0.3",
+      "version": "9.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "which": "^5.0.0"
+        "which": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "4.0.1",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4166,68 +4243,57 @@
         "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
-      "version": "3.2.2",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "9.1.0",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/node-gyp": "^4.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "node-gyp": "^11.0.0",
-        "proc-log": "^5.0.0",
-        "which": "^5.0.0"
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "node-gyp": "^12.1.0",
+        "proc-log": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
-      "version": "3.1.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.4.0"
+        "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "2.0.0",
+      "version": "3.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.4.3",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -4236,47 +4302,47 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.0",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/tuf": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "tuf-js": "^4.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/verify": {
       "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "make-fetch-happen": "^14.0.2",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1"
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.1.0",
+        "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.4.1",
-        "tuf-js": "^3.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
@@ -4288,13 +4354,26 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/@tufjs/models": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^10.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/npm/node_modules/abbrev": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/agent-base": {
@@ -4304,27 +4383,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/aproba": {
@@ -4340,69 +4398,73 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/bin-links": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^7.0.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "read-cmd-shim": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.3.0",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/npm/node_modules/bin-links": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/binary-extensions": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "19.0.1",
+      "version": "20.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^4.0.0",
+        "@npmcli/fs": "^5.0.0",
         "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
         "minipass": "^7.0.3",
         "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
-        "tar": "^7.4.3",
-        "unique-filename": "^4.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/chalk": {
@@ -4442,90 +4504,30 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "4.1.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "^5.0.0"
-      },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
+        "node": ">=20"
       }
     },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "7.0.0",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/npm/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": ">= 18"
       }
     },
     "node_modules/npm/node_modules/cssesc": {
@@ -4558,34 +4560,12 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.2.2",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/npm/node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
@@ -4596,12 +4576,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -4618,39 +4592,6 @@
         "node": ">= 4.9.1"
       }
     },
-    "node_modules/npm/node_modules/fdir": {
-      "version": "6.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/npm/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
       "dev": true,
@@ -4664,20 +4605,17 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.5.0",
+      "version": "13.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4690,15 +4628,15 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "8.1.0",
+      "version": "9.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^10.0.1"
+        "lru-cache": "^11.1.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
@@ -4734,7 +4672,7 @@
       }
     },
     "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.7.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4744,58 +4682,52 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "7.0.0",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minimatch": "^9.0.0"
+        "minimatch": "^10.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "7.0.2",
+      "version": "8.2.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/package-json": "^6.0.0",
-        "npm-package-arg": "^12.0.0",
-        "promzard": "^2.0.0",
-        "read": "^4.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^6.0.0"
+        "@npmcli/package-json": "^7.0.0",
+        "npm-package-arg": "^13.0.0",
+        "promzard": "^3.0.1",
+        "read": "^5.0.1",
+        "semver": "^7.7.2",
+        "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4803,67 +4735,34 @@
         "node": ">= 12"
       }
     },
-    "node_modules/npm/node_modules/ip-regex": {
+    "node_modules/npm/node_modules/is-cidr": {
+      "version": "6.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "cidr-regex": "^5.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/npm/node_modules/isexe": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/is-cidr": {
-      "version": "5.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cidr-regex": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/isexe": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
@@ -4897,209 +4796,202 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "9.0.0",
+      "version": "10.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^12.0.0",
-        "npm-registry-fetch": "^18.0.1"
+        "npm-package-arg": "^13.0.0",
+        "npm-registry-fetch": "^19.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "7.0.5",
+      "version": "8.1.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.5",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "binary-extensions": "^2.3.0",
-        "diff": "^5.1.0",
-        "minimatch": "^9.0.4",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^19.0.0",
-        "tar": "^7.5.11"
+        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "binary-extensions": "^3.0.0",
+        "diff": "^8.0.2",
+        "minimatch": "^10.0.3",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2",
+        "tar": "^7.5.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "9.0.5",
+      "version": "10.2.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.5",
-        "@npmcli/run-script": "^9.0.1",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^19.0.0",
-        "proc-log": "^5.0.0",
-        "read": "^4.0.0",
-        "read-package-json-fast": "^4.0.0",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2",
+        "proc-log": "^6.0.0",
+        "read": "^5.0.1",
         "semver": "^7.3.7",
-        "walk-up-path": "^3.0.1"
+        "signal-exit": "^4.1.0",
+        "walk-up-path": "^4.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "6.0.5",
+      "version": "7.0.21",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.5"
+        "@npmcli/arborist": "^9.5.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmhook": {
-      "version": "11.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "7.0.0",
+      "version": "8.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
+        "npm-registry-fetch": "^19.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "8.0.5",
+      "version": "9.1.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.5",
-        "@npmcli/run-script": "^9.0.1",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^19.0.0"
+        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/run-script": "^10.0.0",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "10.0.2",
+      "version": "11.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/package-json": "^7.0.0",
         "ci-info": "^4.0.0",
-        "normalize-package-data": "^7.0.0",
-        "npm-package-arg": "^12.0.0",
-        "npm-registry-fetch": "^18.0.1",
-        "proc-log": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.7",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0"
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "8.0.0",
+      "version": "9.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^18.0.1"
+        "npm-registry-fetch": "^19.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "7.0.0",
+      "version": "8.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
+        "npm-registry-fetch": "^19.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "7.0.0",
+      "version": "8.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^6.0.1",
-        "@npmcli/run-script": "^9.0.1",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.4.3",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "14.0.3",
+      "version": "15.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/agent": "^3.0.0",
-        "cacache": "^19.0.1",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
+        "minipass-fetch": "^5.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.9",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5127,51 +5019,33 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "4.0.1",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
+        "minipass-sized": "^2.0.0",
         "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       },
       "optionalDependencies": {
-        "encoding": "^0.1.13"
+        "iconv-lite": "^0.7.2"
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -5204,34 +5078,16 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "3.1.0",
@@ -5252,12 +5108,12 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/negotiator": {
@@ -5270,7 +5126,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "11.5.0",
+      "version": "12.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5278,73 +5134,59 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^14.0.3",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.4.3",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
-        "which": "^5.0.0"
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/nopt": {
-      "version": "8.1.0",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^3.0.0"
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "7.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^8.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "6.0.0",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-normalize-package-bin": "^4.0.0"
+        "npm-normalize-package-bin": "^5.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "7.1.2",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -5352,99 +5194,100 @@
         "semver": "^7.1.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "12.0.2",
+      "version": "13.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "hosted-git-info": "^8.0.0",
-        "proc-log": "^5.0.0",
+        "hosted-git-info": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^6.0.0"
+        "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "9.0.0",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "ignore-walk": "^7.0.0"
+        "ignore-walk": "^8.0.0",
+        "proc-log": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "10.0.0",
+      "version": "11.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-install-checks": "^7.1.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "npm-package-arg": "^12.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "11.0.1",
+      "version": "12.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0"
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "18.0.2",
+      "version": "19.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/redact": "^3.0.0",
+        "@npmcli/redact": "^4.0.0",
         "jsonparse": "^1.3.1",
-        "make-fetch-happen": "^14.0.0",
+        "make-fetch-happen": "^15.0.0",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
+        "minipass-fetch": "^5.0.0",
         "minizlib": "^3.0.1",
-        "npm-package-arg": "^12.0.0",
-        "proc-log": "^5.0.0"
+        "npm-package-arg": "^13.0.0",
+        "proc-log": "^6.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/p-map": {
@@ -5459,92 +5302,65 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm/node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/npm/node_modules/pacote": {
-      "version": "19.0.2",
+      "version": "21.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "@npmcli/run-script": "^9.0.0",
-        "cacache": "^19.0.0",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "cacache": "^20.0.0",
         "fs-minipass": "^3.0.0",
         "minipass": "^7.0.2",
-        "npm-package-arg": "^12.0.0",
-        "npm-packlist": "^9.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0",
-        "tar": "^7.5.10"
+        "npm-package-arg": "^13.0.0",
+        "npm-packlist": "^10.0.1",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0",
+        "tar": "^7.4.3"
       },
       "bin": {
         "pacote": "bin/index.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "4.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^4.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
         "just-diff": "^6.0.0",
         "just-diff-apply": "^5.2.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/path-key": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.11.1",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/picomatch": {
-      "version": "4.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
@@ -5561,21 +5377,21 @@
       }
     },
     "node_modules/npm/node_modules/proc-log": {
-      "version": "5.0.0",
+      "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/proggy": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -5596,29 +5412,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
-      "version": "2.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "^4.0.0"
+        "read": "^5.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
@@ -5630,46 +5433,24 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "4.1.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "^2.0.0"
+        "mute-stream": "^3.0.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^4.0.0",
-        "npm-normalize-package-bin": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/safer-buffer": {
@@ -5691,27 +5472,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/npm/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
       "dev": true,
@@ -5725,20 +5485,20 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "3.1.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "@sigstore/sign": "^3.1.0",
-        "@sigstore/tuf": "^3.1.0",
-        "@sigstore/verify": "^2.1.0"
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.1.0",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "@sigstore/sign": "^4.1.0",
+        "@sigstore/tuf": "^4.0.1",
+        "@sigstore/verify": "^3.1.0"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/smart-buffer": {
@@ -5752,12 +5512,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.8",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -5777,26 +5537,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
@@ -5822,7 +5562,7 @@
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "12.0.0",
+      "version": "13.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5830,77 +5570,23 @@
         "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/supports-color": {
-      "version": "9.4.0",
+      "version": "10.2.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.13",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -5922,25 +5608,54 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
-      "version": "1.3.0",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/npm/node_modules/treeverse": {
@@ -5953,54 +5668,26 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "3.1.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "3.0.1",
-        "debug": "^4.4.1",
-        "make-fetch-happen": "^14.0.3"
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
-      "version": "3.0.1",
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.25.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.5"
-      },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -6009,176 +5696,49 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "6.0.2",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "5.0.0",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^4.0.0"
       },
       "bin": {
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/which/node_modules/isexe": {
-      "version": "3.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "6.0.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/yallist": {
@@ -6446,6 +6006,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pify": {
       "version": "3.0.0",
@@ -7438,6 +7011,19 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -7562,19 +7148,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7659,6 +7232,16 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7708,6 +7291,16 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/unicode-emoji-modifier-base": {
@@ -7956,6 +7549,41 @@
     }
   },
   "dependencies": {
+    "@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
+      "requires": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
+      "requires": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
+      "requires": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "dev": true
+    },
     "@as-covers/assembly": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@as-covers/assembly/-/assembly-0.4.1.tgz",
@@ -8520,24 +8148,112 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.2.tgz",
-      "integrity": "sha512-+M9/Lb35IgnlUO6OSJ40Ie+hUsZLuph2fqXC/qrKn0fMvUU/jiCjpoL6zEm69vzcmaZJ8yNKtMBEKHWN49WBbQ==",
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.5.tgz",
+      "integrity": "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==",
       "dev": true,
       "requires": {
+        "@actions/core": "^3.0.0",
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^5.0.0",
+        "env-ci": "^11.2.0",
         "execa": "^9.0.0",
         "fs-extra": "^11.0.0",
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^8.0.0",
-        "npm": "^10.9.3",
+        "normalize-url": "^9.0.0",
+        "npm": "^11.6.2",
         "rc": "^1.2.8",
-        "read-pkg": "^9.0.0",
+        "read-pkg": "^10.0.0",
         "registry-auth-token": "^5.0.0",
         "semver": "^7.1.2",
         "tempy": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.29.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+          "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.28.5",
+            "js-tokens": "^4.0.0",
+            "picocolors": "^1.1.1"
+          }
+        },
+        "hosted-git-info": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+          "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^11.1.0"
+          }
+        },
+        "lru-cache": {
+          "version": "11.3.6",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+          "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+          "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^9.0.0",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4"
+          }
+        },
+        "parse-json": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+          "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.26.2",
+            "index-to-position": "^1.1.0",
+            "type-fest": "^4.39.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "4.41.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+              "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+          "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.4",
+            "normalize-package-data": "^8.0.0",
+            "parse-json": "^8.3.0",
+            "type-fest": "^5.4.4",
+            "unicorn-magic": "^0.4.0"
+          }
+        },
+        "type-fest": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+          "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+          "dev": true,
+          "requires": {
+            "tagged-tag": "^1.0.0"
+          }
+        },
+        "unicorn-magic": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+          "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+          "dev": true
+        }
       }
     },
     "@semantic-release/release-notes-generator": {
@@ -9624,9 +9340,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true
     },
     "fastq": {
@@ -10502,129 +10218,88 @@
       }
     },
     "normalize-url": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
-      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.0.tgz",
+      "integrity": "sha512-z9nC87iaZXXySbWWtTHfCFJyFvKaUAW6lODhikG7ILSbVgmwuFjUqkgnheHvAUcGedO29e2QGBRXMUD64aurqQ==",
       "dev": true
     },
     "npm": {
-      "version": "10.9.8",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.8.tgz",
-      "integrity": "sha512-fYwb6ODSmHkqrJQQaCxY3M2lPf/mpgC7ik0HSzzIwG5CGtabRp4bNqikatvCoT42b5INQSqudVH0R7yVmC9hVg==",
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
+      "integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^8.0.5",
-        "@npmcli/config": "^9.0.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/map-workspaces": "^4.0.2",
-        "@npmcli/package-json": "^6.2.0",
-        "@npmcli/promise-spawn": "^8.0.3",
-        "@npmcli/redact": "^3.2.2",
-        "@npmcli/run-script": "^9.1.0",
-        "@sigstore/tuf": "^3.1.1",
-        "abbrev": "^3.0.1",
+        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/config": "^10.9.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/map-workspaces": "^5.0.3",
+        "@npmcli/metavuln-calculator": "^9.0.3",
+        "@npmcli/package-json": "^7.0.5",
+        "@npmcli/promise-spawn": "^9.0.1",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.4",
+        "@sigstore/tuf": "^4.0.2",
+        "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^19.0.1",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
         "ci-info": "^4.4.0",
-        "cli-columns": "^4.0.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^10.5.0",
+        "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^8.1.0",
-        "ini": "^5.0.0",
-        "init-package-json": "^7.0.2",
-        "is-cidr": "^5.1.1",
-        "json-parse-even-better-errors": "^4.0.0",
-        "libnpmaccess": "^9.0.0",
-        "libnpmdiff": "^7.0.5",
-        "libnpmexec": "^9.0.5",
-        "libnpmfund": "^6.0.5",
-        "libnpmhook": "^11.0.0",
-        "libnpmorg": "^7.0.0",
-        "libnpmpack": "^8.0.5",
-        "libnpmpublish": "^10.0.2",
-        "libnpmsearch": "^8.0.0",
-        "libnpmteam": "^7.0.0",
-        "libnpmversion": "^7.0.0",
-        "make-fetch-happen": "^14.0.3",
-        "minimatch": "^9.0.9",
+        "hosted-git-info": "^9.0.2",
+        "ini": "^6.0.0",
+        "init-package-json": "^8.2.5",
+        "is-cidr": "^6.0.4",
+        "json-parse-even-better-errors": "^5.0.0",
+        "libnpmaccess": "^10.0.3",
+        "libnpmdiff": "^8.1.7",
+        "libnpmexec": "^10.2.7",
+        "libnpmfund": "^7.0.21",
+        "libnpmorg": "^8.0.1",
+        "libnpmpack": "^9.1.7",
+        "libnpmpublish": "^11.1.3",
+        "libnpmsearch": "^9.0.1",
+        "libnpmteam": "^8.0.2",
+        "libnpmversion": "^8.0.3",
+        "make-fetch-happen": "^15.0.5",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^11.5.0",
-        "nopt": "^8.1.0",
-        "normalize-package-data": "^7.0.1",
-        "npm-audit-report": "^6.0.0",
-        "npm-install-checks": "^7.1.2",
-        "npm-package-arg": "^12.0.2",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-profile": "^11.0.1",
-        "npm-registry-fetch": "^18.0.2",
-        "npm-user-validate": "^3.0.0",
+        "node-gyp": "^12.3.0",
+        "nopt": "^9.0.0",
+        "npm-audit-report": "^7.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.2",
+        "npm-pick-manifest": "^11.0.3",
+        "npm-profile": "^12.0.1",
+        "npm-registry-fetch": "^19.1.1",
+        "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^19.0.1",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
+        "pacote": "^21.5.0",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^4.1.0",
+        "read": "^5.0.1",
         "semver": "^7.7.4",
         "spdx-expression-parse": "^4.0.0",
-        "ssri": "^12.0.0",
-        "supports-color": "^9.4.0",
-        "tar": "^7.5.11",
+        "ssri": "^13.0.1",
+        "supports-color": "^10.2.2",
+        "tar": "^7.5.13",
         "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
+        "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^6.0.2",
-        "which": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1"
       },
       "dependencies": {
-        "@isaacs/cliui": {
-          "version": "8.0.2",
+        "@gar/promise-retry": {
+          "version": "1.0.3",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^5.1.2",
-            "string-width-cjs": "npm:string-width@^4.2.0",
-            "strip-ansi": "^7.0.1",
-            "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-            "wrap-ansi": "^8.1.0",
-            "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "6.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "emoji-regex": {
-              "version": "9.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "7.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^6.2.2"
-              }
-            }
-          }
+          "dev": true
         },
         "@isaacs/fs-minipass": {
           "version": "4.0.1",
@@ -10640,77 +10315,75 @@
           "dev": true
         },
         "@npmcli/agent": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "agent-base": "^7.1.0",
             "http-proxy-agent": "^7.0.0",
             "https-proxy-agent": "^7.0.1",
-            "lru-cache": "^10.0.1",
+            "lru-cache": "^11.2.1",
             "socks-proxy-agent": "^8.0.3"
           }
         },
         "@npmcli/arborist": {
-          "version": "8.0.5",
+          "version": "9.5.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@gar/promise-retry": "^1.0.0",
             "@isaacs/string-locale-compare": "^1.1.0",
-            "@npmcli/fs": "^4.0.0",
-            "@npmcli/installed-package-contents": "^3.0.0",
-            "@npmcli/map-workspaces": "^4.0.1",
-            "@npmcli/metavuln-calculator": "^8.0.0",
-            "@npmcli/name-from-folder": "^3.0.0",
-            "@npmcli/node-gyp": "^4.0.0",
-            "@npmcli/package-json": "^6.0.1",
-            "@npmcli/query": "^4.0.0",
-            "@npmcli/redact": "^3.0.0",
-            "@npmcli/run-script": "^9.0.1",
-            "bin-links": "^5.0.0",
-            "cacache": "^19.0.1",
-            "common-ancestor-path": "^1.0.1",
-            "hosted-git-info": "^8.0.0",
-            "json-parse-even-better-errors": "^4.0.0",
+            "@npmcli/fs": "^5.0.0",
+            "@npmcli/installed-package-contents": "^4.0.0",
+            "@npmcli/map-workspaces": "^5.0.0",
+            "@npmcli/metavuln-calculator": "^9.0.2",
+            "@npmcli/name-from-folder": "^4.0.0",
+            "@npmcli/node-gyp": "^5.0.0",
+            "@npmcli/package-json": "^7.0.0",
+            "@npmcli/query": "^5.0.0",
+            "@npmcli/redact": "^4.0.0",
+            "@npmcli/run-script": "^10.0.0",
+            "bin-links": "^6.0.0",
+            "cacache": "^20.0.1",
+            "common-ancestor-path": "^2.0.0",
+            "hosted-git-info": "^9.0.0",
             "json-stringify-nice": "^1.1.4",
-            "lru-cache": "^10.2.2",
-            "minimatch": "^9.0.4",
-            "nopt": "^8.0.0",
-            "npm-install-checks": "^7.1.0",
-            "npm-package-arg": "^12.0.0",
-            "npm-pick-manifest": "^10.0.0",
-            "npm-registry-fetch": "^18.0.1",
-            "pacote": "^19.0.0",
-            "parse-conflict-json": "^4.0.0",
-            "proc-log": "^5.0.0",
-            "proggy": "^3.0.0",
+            "lru-cache": "^11.2.1",
+            "minimatch": "^10.0.3",
+            "nopt": "^9.0.0",
+            "npm-install-checks": "^8.0.0",
+            "npm-package-arg": "^13.0.0",
+            "npm-pick-manifest": "^11.0.1",
+            "npm-registry-fetch": "^19.0.0",
+            "pacote": "^21.0.2",
+            "parse-conflict-json": "^5.0.1",
+            "proc-log": "^6.0.0",
+            "proggy": "^4.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^3.0.1",
-            "promise-retry": "^2.0.1",
-            "read-package-json-fast": "^4.0.0",
             "semver": "^7.3.7",
-            "ssri": "^12.0.0",
+            "ssri": "^13.0.0",
             "treeverse": "^3.0.0",
-            "walk-up-path": "^3.0.1"
+            "walk-up-path": "^4.0.0"
           }
         },
         "@npmcli/config": {
-          "version": "9.0.0",
+          "version": "10.9.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/map-workspaces": "^4.0.1",
-            "@npmcli/package-json": "^6.0.1",
+            "@npmcli/map-workspaces": "^5.0.0",
+            "@npmcli/package-json": "^7.0.0",
             "ci-info": "^4.0.0",
-            "ini": "^5.0.0",
-            "nopt": "^8.0.0",
-            "proc-log": "^5.0.0",
+            "ini": "^6.0.0",
+            "nopt": "^9.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.5",
-            "walk-up-path": "^3.0.1"
+            "walk-up-path": "^4.0.0"
           }
         },
         "@npmcli/fs": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10718,112 +10391,86 @@
           }
         },
         "@npmcli/git": {
-          "version": "6.0.3",
+          "version": "7.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/promise-spawn": "^8.0.0",
-            "ini": "^5.0.0",
-            "lru-cache": "^10.0.1",
-            "npm-pick-manifest": "^10.0.0",
-            "proc-log": "^5.0.0",
-            "promise-retry": "^2.0.1",
+            "@gar/promise-retry": "^1.0.0",
+            "@npmcli/promise-spawn": "^9.0.0",
+            "ini": "^6.0.0",
+            "lru-cache": "^11.2.1",
+            "npm-pick-manifest": "^11.0.1",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.5",
-            "which": "^5.0.0"
+            "which": "^6.0.0"
           }
         },
         "@npmcli/installed-package-contents": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-bundled": "^4.0.0",
-            "npm-normalize-package-bin": "^4.0.0"
+            "npm-bundled": "^5.0.0",
+            "npm-normalize-package-bin": "^5.0.0"
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "4.0.2",
+          "version": "5.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/name-from-folder": "^3.0.0",
-            "@npmcli/package-json": "^6.0.0",
-            "glob": "^10.2.2",
-            "minimatch": "^9.0.0"
+            "@npmcli/name-from-folder": "^4.0.0",
+            "@npmcli/package-json": "^7.0.0",
+            "glob": "^13.0.0",
+            "minimatch": "^10.0.3"
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "8.0.1",
+          "version": "9.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cacache": "^19.0.0",
-            "json-parse-even-better-errors": "^4.0.0",
-            "pacote": "^20.0.0",
-            "proc-log": "^5.0.0",
+            "cacache": "^20.0.0",
+            "json-parse-even-better-errors": "^5.0.0",
+            "pacote": "^21.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.5"
-          },
-          "dependencies": {
-            "pacote": {
-              "version": "20.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@npmcli/git": "^6.0.0",
-                "@npmcli/installed-package-contents": "^3.0.0",
-                "@npmcli/package-json": "^6.0.0",
-                "@npmcli/promise-spawn": "^8.0.0",
-                "@npmcli/run-script": "^9.0.0",
-                "cacache": "^19.0.0",
-                "fs-minipass": "^3.0.0",
-                "minipass": "^7.0.2",
-                "npm-package-arg": "^12.0.0",
-                "npm-packlist": "^9.0.0",
-                "npm-pick-manifest": "^10.0.0",
-                "npm-registry-fetch": "^18.0.0",
-                "proc-log": "^5.0.0",
-                "promise-retry": "^2.0.1",
-                "sigstore": "^3.0.0",
-                "ssri": "^12.0.0",
-                "tar": "^7.5.10"
-              }
-            }
           }
         },
         "@npmcli/name-from-folder": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "@npmcli/node-gyp": {
           "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
+        "@npmcli/node-gyp": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "@npmcli/package-json": {
-          "version": "6.2.0",
+          "version": "7.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^6.0.0",
-            "glob": "^10.2.2",
-            "hosted-git-info": "^8.0.0",
-            "json-parse-even-better-errors": "^4.0.0",
-            "proc-log": "^5.0.0",
+            "@npmcli/git": "^7.0.0",
+            "glob": "^13.0.0",
+            "hosted-git-info": "^9.0.0",
+            "json-parse-even-better-errors": "^5.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.5.3",
-            "validate-npm-package-license": "^3.0.4"
+            "spdx-expression-parse": "^4.0.0"
           }
         },
         "@npmcli/promise-spawn": {
-          "version": "8.0.3",
+          "version": "9.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "which": "^5.0.0"
+            "which": "^6.0.0"
           }
         },
         "@npmcli/query": {
-          "version": "4.0.1",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10831,77 +10478,70 @@
           }
         },
         "@npmcli/redact": {
-          "version": "3.2.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/run-script": {
-          "version": "9.1.0",
+          "version": "10.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/node-gyp": "^4.0.0",
-            "@npmcli/package-json": "^6.0.0",
-            "@npmcli/promise-spawn": "^8.0.0",
-            "node-gyp": "^11.0.0",
-            "proc-log": "^5.0.0",
-            "which": "^5.0.0"
+            "@npmcli/node-gyp": "^5.0.0",
+            "@npmcli/package-json": "^7.0.0",
+            "@npmcli/promise-spawn": "^9.0.0",
+            "node-gyp": "^12.1.0",
+            "proc-log": "^6.0.0"
           }
         },
-        "@pkgjs/parseargs": {
-          "version": "0.11.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "@sigstore/bundle": {
-          "version": "3.1.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/protobuf-specs": "^0.4.0"
+            "@sigstore/protobuf-specs": "^0.5.0"
           }
         },
         "@sigstore/core": {
-          "version": "2.0.0",
+          "version": "3.2.0",
           "bundled": true,
           "dev": true
         },
         "@sigstore/protobuf-specs": {
-          "version": "0.4.3",
+          "version": "0.5.1",
           "bundled": true,
           "dev": true
         },
         "@sigstore/sign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@gar/promise-retry": "^1.0.2",
+            "@sigstore/bundle": "^4.0.0",
+            "@sigstore/core": "^3.2.0",
+            "@sigstore/protobuf-specs": "^0.5.0",
+            "make-fetch-happen": "^15.0.4",
+            "proc-log": "^6.1.0"
+          }
+        },
+        "@sigstore/tuf": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@sigstore/protobuf-specs": "^0.5.0",
+            "tuf-js": "^4.1.0"
+          }
+        },
+        "@sigstore/verify": {
           "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/bundle": "^3.1.0",
-            "@sigstore/core": "^2.0.0",
-            "@sigstore/protobuf-specs": "^0.4.0",
-            "make-fetch-happen": "^14.0.2",
-            "proc-log": "^5.0.0",
-            "promise-retry": "^2.0.1"
-          }
-        },
-        "@sigstore/tuf": {
-          "version": "3.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@sigstore/protobuf-specs": "^0.4.1",
-            "tuf-js": "^3.0.1"
-          }
-        },
-        "@sigstore/verify": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@sigstore/bundle": "^3.1.0",
-            "@sigstore/core": "^2.0.0",
-            "@sigstore/protobuf-specs": "^0.4.1"
+            "@sigstore/bundle": "^4.0.0",
+            "@sigstore/core": "^3.1.0",
+            "@sigstore/protobuf-specs": "^0.5.0"
           }
         },
         "@tufjs/canonical-json": {
@@ -10909,23 +10549,22 @@
           "bundled": true,
           "dev": true
         },
+        "@tufjs/models": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@tufjs/canonical-json": "2.0.0",
+            "minimatch": "^10.1.1"
+          }
+        },
         "abbrev": {
-          "version": "3.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
         "agent-base": {
           "version": "7.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "6.2.3",
           "bundled": true,
           "dev": true
         },
@@ -10940,52 +10579,50 @@
           "dev": true
         },
         "balanced-match": {
-          "version": "1.0.2",
+          "version": "4.0.4",
           "bundled": true,
           "dev": true
         },
         "bin-links": {
-          "version": "5.0.0",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cmd-shim": "^7.0.0",
-            "npm-normalize-package-bin": "^4.0.0",
-            "proc-log": "^5.0.0",
-            "read-cmd-shim": "^5.0.0",
-            "write-file-atomic": "^6.0.0"
+            "cmd-shim": "^8.0.0",
+            "npm-normalize-package-bin": "^5.0.0",
+            "proc-log": "^6.0.0",
+            "read-cmd-shim": "^6.0.0",
+            "write-file-atomic": "^7.0.0"
           }
         },
         "binary-extensions": {
-          "version": "2.3.0",
+          "version": "3.1.0",
           "bundled": true,
           "dev": true
         },
         "brace-expansion": {
-          "version": "2.0.2",
+          "version": "5.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0"
+            "balanced-match": "^4.0.2"
           }
         },
         "cacache": {
-          "version": "19.0.1",
+          "version": "20.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/fs": "^4.0.0",
+            "@npmcli/fs": "^5.0.0",
             "fs-minipass": "^3.0.0",
-            "glob": "^10.2.2",
-            "lru-cache": "^10.0.1",
+            "glob": "^13.0.0",
+            "lru-cache": "^11.1.0",
             "minipass": "^7.0.3",
             "minipass-collect": "^2.0.1",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "p-map": "^7.0.2",
-            "ssri": "^12.0.0",
-            "tar": "^7.4.3",
-            "unique-filename": "^4.0.0"
+            "ssri": "^13.0.0"
           }
         },
         "chalk": {
@@ -11004,64 +10641,19 @@
           "dev": true
         },
         "cidr-regex": {
-          "version": "4.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ip-regex": "^5.0.0"
-          }
-        },
-        "cli-columns": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "cmd-shim": {
-          "version": "7.0.0",
+          "version": "5.0.5",
           "bundled": true,
           "dev": true
         },
-        "color-convert": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
+        "cmd-shim": {
+          "version": "8.0.0",
           "bundled": true,
           "dev": true
         },
         "common-ancestor-path": {
-          "version": "1.0.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
-        },
-        "cross-spawn": {
-          "version": "7.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          },
-          "dependencies": {
-            "which": {
-              "version": "2.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            }
-          }
         },
         "cssesc": {
           "version": "3.0.0",
@@ -11077,36 +10669,12 @@
           }
         },
         "diff": {
-          "version": "5.2.2",
+          "version": "8.0.4",
           "bundled": true,
           "dev": true
-        },
-        "eastasianwidth": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "encoding": {
-          "version": "0.1.13",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "iconv-lite": "^0.6.2"
-          }
         },
         "env-paths": {
           "version": "2.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "err-code": {
-          "version": "2.0.3",
           "bundled": true,
           "dev": true
         },
@@ -11120,20 +10688,6 @@
           "bundled": true,
           "dev": true
         },
-        "fdir": {
-          "version": "6.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "foreground-child": {
-          "version": "3.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.6",
-            "signal-exit": "^4.0.1"
-          }
-        },
         "fs-minipass": {
           "version": "3.0.3",
           "bundled": true,
@@ -11143,16 +10697,13 @@
           }
         },
         "glob": {
-          "version": "10.5.0",
+          "version": "13.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "^3.1.0",
-            "jackspeak": "^3.1.2",
-            "minimatch": "^9.0.4",
-            "minipass": "^7.1.2",
-            "package-json-from-dist": "^1.0.0",
-            "path-scurry": "^1.11.1"
+            "minimatch": "^10.2.2",
+            "minipass": "^7.1.3",
+            "path-scurry": "^2.0.2"
           }
         },
         "graceful-fs": {
@@ -11161,11 +10712,11 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "8.1.0",
+          "version": "9.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^10.0.1"
+            "lru-cache": "^11.1.0"
           }
         },
         "http-cache-semantics": {
@@ -11192,7 +10743,7 @@
           }
         },
         "iconv-lite": {
-          "version": "0.6.3",
+          "version": "0.7.2",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -11201,76 +10752,51 @@
           }
         },
         "ignore-walk": {
-          "version": "7.0.0",
+          "version": "8.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimatch": "^9.0.0"
+            "minimatch": "^10.0.3"
           }
         },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
         "ini": {
-          "version": "5.0.0",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true
         },
         "init-package-json": {
-          "version": "7.0.2",
+          "version": "8.2.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/package-json": "^6.0.0",
-            "npm-package-arg": "^12.0.0",
-            "promzard": "^2.0.0",
-            "read": "^4.0.0",
-            "semver": "^7.3.5",
-            "validate-npm-package-license": "^3.0.4",
-            "validate-npm-package-name": "^6.0.0"
+            "@npmcli/package-json": "^7.0.0",
+            "npm-package-arg": "^13.0.0",
+            "promzard": "^3.0.1",
+            "read": "^5.0.1",
+            "semver": "^7.7.2",
+            "validate-npm-package-name": "^7.0.0"
           }
         },
         "ip-address": {
-          "version": "10.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "ip-regex": {
-          "version": "5.0.0",
+          "version": "10.1.1",
           "bundled": true,
           "dev": true
         },
         "is-cidr": {
-          "version": "5.1.1",
+          "version": "6.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "^4.1.1"
+            "cidr-regex": "^5.0.4"
           }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
         },
         "isexe": {
-          "version": "2.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
-        "jackspeak": {
-          "version": "3.4.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@isaacs/cliui": "^8.0.2",
-            "@pkgjs/parseargs": "^0.11.0"
-          }
-        },
         "json-parse-even-better-errors": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true
         },
@@ -11295,156 +10821,150 @@
           "dev": true
         },
         "libnpmaccess": {
-          "version": "9.0.0",
+          "version": "10.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "^12.0.0",
-            "npm-registry-fetch": "^18.0.1"
+            "npm-package-arg": "^13.0.0",
+            "npm-registry-fetch": "^19.0.0"
           }
         },
         "libnpmdiff": {
-          "version": "7.0.5",
+          "version": "8.1.7",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^8.0.5",
-            "@npmcli/installed-package-contents": "^3.0.0",
-            "binary-extensions": "^2.3.0",
-            "diff": "^5.1.0",
-            "minimatch": "^9.0.4",
-            "npm-package-arg": "^12.0.0",
-            "pacote": "^19.0.0",
-            "tar": "^7.5.11"
+            "@npmcli/arborist": "^9.5.0",
+            "@npmcli/installed-package-contents": "^4.0.0",
+            "binary-extensions": "^3.0.0",
+            "diff": "^8.0.2",
+            "minimatch": "^10.0.3",
+            "npm-package-arg": "^13.0.0",
+            "pacote": "^21.0.2",
+            "tar": "^7.5.1"
           }
         },
         "libnpmexec": {
-          "version": "9.0.5",
+          "version": "10.2.7",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^8.0.5",
-            "@npmcli/run-script": "^9.0.1",
+            "@gar/promise-retry": "^1.0.0",
+            "@npmcli/arborist": "^9.5.0",
+            "@npmcli/package-json": "^7.0.0",
+            "@npmcli/run-script": "^10.0.0",
             "ci-info": "^4.0.0",
-            "npm-package-arg": "^12.0.0",
-            "pacote": "^19.0.0",
-            "proc-log": "^5.0.0",
-            "read": "^4.0.0",
-            "read-package-json-fast": "^4.0.0",
+            "npm-package-arg": "^13.0.0",
+            "pacote": "^21.0.2",
+            "proc-log": "^6.0.0",
+            "read": "^5.0.1",
             "semver": "^7.3.7",
-            "walk-up-path": "^3.0.1"
+            "signal-exit": "^4.1.0",
+            "walk-up-path": "^4.0.0"
           }
         },
         "libnpmfund": {
-          "version": "6.0.5",
+          "version": "7.0.21",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^8.0.5"
-          }
-        },
-        "libnpmhook": {
-          "version": "11.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "npm-registry-fetch": "^18.0.1"
+            "@npmcli/arborist": "^9.5.0"
           }
         },
         "libnpmorg": {
-          "version": "7.0.0",
+          "version": "8.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^18.0.1"
+            "npm-registry-fetch": "^19.0.0"
           }
         },
         "libnpmpack": {
-          "version": "8.0.5",
+          "version": "9.1.7",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^8.0.5",
-            "@npmcli/run-script": "^9.0.1",
-            "npm-package-arg": "^12.0.0",
-            "pacote": "^19.0.0"
+            "@npmcli/arborist": "^9.5.0",
+            "@npmcli/run-script": "^10.0.0",
+            "npm-package-arg": "^13.0.0",
+            "pacote": "^21.0.2"
           }
         },
         "libnpmpublish": {
-          "version": "10.0.2",
+          "version": "11.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@npmcli/package-json": "^7.0.0",
             "ci-info": "^4.0.0",
-            "normalize-package-data": "^7.0.0",
-            "npm-package-arg": "^12.0.0",
-            "npm-registry-fetch": "^18.0.1",
-            "proc-log": "^5.0.0",
+            "npm-package-arg": "^13.0.0",
+            "npm-registry-fetch": "^19.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.7",
-            "sigstore": "^3.0.0",
-            "ssri": "^12.0.0"
+            "sigstore": "^4.0.0",
+            "ssri": "^13.0.0"
           }
         },
         "libnpmsearch": {
-          "version": "8.0.0",
+          "version": "9.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^18.0.1"
+            "npm-registry-fetch": "^19.0.0"
           }
         },
         "libnpmteam": {
-          "version": "7.0.0",
+          "version": "8.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^18.0.1"
+            "npm-registry-fetch": "^19.0.0"
           }
         },
         "libnpmversion": {
-          "version": "7.0.0",
+          "version": "8.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^6.0.1",
-            "@npmcli/run-script": "^9.0.1",
-            "json-parse-even-better-errors": "^4.0.0",
-            "proc-log": "^5.0.0",
+            "@npmcli/git": "^7.0.0",
+            "@npmcli/run-script": "^10.0.0",
+            "json-parse-even-better-errors": "^5.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.7"
           }
         },
         "lru-cache": {
-          "version": "10.4.3",
+          "version": "11.3.5",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "14.0.3",
+          "version": "15.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/agent": "^3.0.0",
-            "cacache": "^19.0.1",
+            "@gar/promise-retry": "^1.0.0",
+            "@npmcli/agent": "^4.0.0",
+            "@npmcli/redact": "^4.0.0",
+            "cacache": "^20.0.1",
             "http-cache-semantics": "^4.1.1",
             "minipass": "^7.0.2",
-            "minipass-fetch": "^4.0.0",
+            "minipass-fetch": "^5.0.0",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^1.0.0",
-            "proc-log": "^5.0.0",
-            "promise-retry": "^2.0.1",
-            "ssri": "^12.0.0"
+            "proc-log": "^6.0.0",
+            "ssri": "^13.0.0"
           }
         },
         "minimatch": {
-          "version": "9.0.9",
+          "version": "10.2.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.0.2"
+            "brace-expansion": "^5.0.5"
           }
         },
         "minipass": {
@@ -11461,37 +10981,22 @@
           }
         },
         "minipass-fetch": {
-          "version": "4.0.1",
+          "version": "5.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "encoding": "^0.1.13",
+            "iconv-lite": "^0.7.2",
             "minipass": "^7.0.3",
-            "minipass-sized": "^1.0.3",
+            "minipass-sized": "^2.0.0",
             "minizlib": "^3.0.1"
           }
         },
         "minipass-flush": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            }
+            "minipass": "^7.1.3"
           }
         },
         "minipass-pipeline": {
@@ -11518,26 +11023,11 @@
           }
         },
         "minipass-sized": {
-          "version": "1.0.3",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            }
+            "minipass": "^7.1.2"
           }
         },
         "minizlib": {
@@ -11554,7 +11044,7 @@
           "dev": true
         },
         "mute-stream": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
@@ -11564,55 +11054,45 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "11.5.0",
+          "version": "12.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "exponential-backoff": "^3.1.1",
             "graceful-fs": "^4.2.6",
-            "make-fetch-happen": "^14.0.3",
-            "nopt": "^8.0.0",
-            "proc-log": "^5.0.0",
+            "nopt": "^9.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.5",
-            "tar": "^7.4.3",
+            "tar": "^7.5.4",
             "tinyglobby": "^0.2.12",
-            "which": "^5.0.0"
+            "undici": "^6.25.0",
+            "which": "^6.0.0"
           }
         },
         "nopt": {
-          "version": "8.1.0",
+          "version": "9.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "^3.0.0"
-          }
-        },
-        "normalize-package-data": {
-          "version": "7.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^8.0.0",
-            "semver": "^7.3.5",
-            "validate-npm-package-license": "^3.0.4"
+            "abbrev": "^4.0.0"
           }
         },
         "npm-audit-report": {
-          "version": "6.0.0",
+          "version": "7.0.0",
           "bundled": true,
           "dev": true
         },
         "npm-bundled": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-normalize-package-bin": "^4.0.0"
+            "npm-normalize-package-bin": "^5.0.0"
           }
         },
         "npm-install-checks": {
-          "version": "7.1.2",
+          "version": "8.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11620,66 +11100,67 @@
           }
         },
         "npm-normalize-package-bin": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true
         },
         "npm-package-arg": {
-          "version": "12.0.2",
+          "version": "13.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^8.0.0",
-            "proc-log": "^5.0.0",
+            "hosted-git-info": "^9.0.0",
+            "proc-log": "^6.0.0",
             "semver": "^7.3.5",
-            "validate-npm-package-name": "^6.0.0"
+            "validate-npm-package-name": "^7.0.0"
           }
         },
         "npm-packlist": {
-          "version": "9.0.0",
+          "version": "10.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ignore-walk": "^7.0.0"
+            "ignore-walk": "^8.0.0",
+            "proc-log": "^6.0.0"
           }
         },
         "npm-pick-manifest": {
-          "version": "10.0.0",
+          "version": "11.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-install-checks": "^7.1.0",
-            "npm-normalize-package-bin": "^4.0.0",
-            "npm-package-arg": "^12.0.0",
+            "npm-install-checks": "^8.0.0",
+            "npm-normalize-package-bin": "^5.0.0",
+            "npm-package-arg": "^13.0.0",
             "semver": "^7.3.5"
           }
         },
         "npm-profile": {
-          "version": "11.0.1",
+          "version": "12.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^18.0.0",
-            "proc-log": "^5.0.0"
+            "npm-registry-fetch": "^19.0.0",
+            "proc-log": "^6.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "18.0.2",
+          "version": "19.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/redact": "^3.0.0",
+            "@npmcli/redact": "^4.0.0",
             "jsonparse": "^1.3.1",
-            "make-fetch-happen": "^14.0.0",
+            "make-fetch-happen": "^15.0.0",
             "minipass": "^7.0.2",
-            "minipass-fetch": "^4.0.0",
+            "minipass-fetch": "^5.0.0",
             "minizlib": "^3.0.1",
-            "npm-package-arg": "^12.0.0",
-            "proc-log": "^5.0.0"
+            "npm-package-arg": "^13.0.0",
+            "proc-log": "^6.0.0"
           }
         },
         "npm-user-validate": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -11688,63 +11169,48 @@
           "bundled": true,
           "dev": true
         },
-        "package-json-from-dist": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "pacote": {
-          "version": "19.0.2",
+          "version": "21.5.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^6.0.0",
-            "@npmcli/installed-package-contents": "^3.0.0",
-            "@npmcli/package-json": "^6.0.0",
-            "@npmcli/promise-spawn": "^8.0.0",
-            "@npmcli/run-script": "^9.0.0",
-            "cacache": "^19.0.0",
+            "@gar/promise-retry": "^1.0.0",
+            "@npmcli/git": "^7.0.0",
+            "@npmcli/installed-package-contents": "^4.0.0",
+            "@npmcli/package-json": "^7.0.0",
+            "@npmcli/promise-spawn": "^9.0.0",
+            "@npmcli/run-script": "^10.0.0",
+            "cacache": "^20.0.0",
             "fs-minipass": "^3.0.0",
             "minipass": "^7.0.2",
-            "npm-package-arg": "^12.0.0",
-            "npm-packlist": "^9.0.0",
-            "npm-pick-manifest": "^10.0.0",
-            "npm-registry-fetch": "^18.0.0",
-            "proc-log": "^5.0.0",
-            "promise-retry": "^2.0.1",
-            "sigstore": "^3.0.0",
-            "ssri": "^12.0.0",
-            "tar": "^7.5.10"
+            "npm-package-arg": "^13.0.0",
+            "npm-packlist": "^10.0.1",
+            "npm-pick-manifest": "^11.0.1",
+            "npm-registry-fetch": "^19.0.0",
+            "proc-log": "^6.0.0",
+            "sigstore": "^4.0.0",
+            "ssri": "^13.0.0",
+            "tar": "^7.4.3"
           }
         },
         "parse-conflict-json": {
-          "version": "4.0.0",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "json-parse-even-better-errors": "^4.0.0",
+            "json-parse-even-better-errors": "^5.0.0",
             "just-diff": "^6.0.0",
             "just-diff-apply": "^5.2.0"
           }
         },
-        "path-key": {
-          "version": "3.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "path-scurry": {
-          "version": "1.11.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^10.2.0",
-            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            "lru-cache": "^11.0.0",
+            "minipass": "^7.1.2"
           }
-        },
-        "picomatch": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true
         },
         "postcss-selector-parser": {
           "version": "7.1.1",
@@ -11756,12 +11222,12 @@
           }
         },
         "proc-log": {
-          "version": "5.0.0",
+          "version": "6.1.0",
           "bundled": true,
           "dev": true
         },
         "proggy": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -11775,21 +11241,12 @@
           "bundled": true,
           "dev": true
         },
-        "promise-retry": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "err-code": "^2.0.2",
-            "retry": "^0.12.0"
-          }
-        },
         "promzard": {
-          "version": "2.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "read": "^4.0.0"
+            "read": "^5.0.0"
           }
         },
         "qrcode-terminal": {
@@ -11798,29 +11255,15 @@
           "dev": true
         },
         "read": {
-          "version": "4.1.0",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mute-stream": "^2.0.0"
+            "mute-stream": "^3.0.0"
           }
         },
         "read-cmd-shim": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "read-package-json-fast": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "json-parse-even-better-errors": "^4.0.0",
-            "npm-normalize-package-bin": "^4.0.0"
-          }
-        },
-        "retry": {
-          "version": "0.12.0",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true
         },
@@ -11835,35 +11278,22 @@
           "bundled": true,
           "dev": true
         },
-        "shebang-command": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "signal-exit": {
           "version": "4.1.0",
           "bundled": true,
           "dev": true
         },
         "sigstore": {
-          "version": "3.1.0",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/bundle": "^3.1.0",
-            "@sigstore/core": "^2.0.0",
-            "@sigstore/protobuf-specs": "^0.4.0",
-            "@sigstore/sign": "^3.1.0",
-            "@sigstore/tuf": "^3.1.0",
-            "@sigstore/verify": "^2.1.0"
+            "@sigstore/bundle": "^4.0.0",
+            "@sigstore/core": "^3.1.0",
+            "@sigstore/protobuf-specs": "^0.5.0",
+            "@sigstore/sign": "^4.1.0",
+            "@sigstore/tuf": "^4.0.1",
+            "@sigstore/verify": "^3.1.0"
           }
         },
         "smart-buffer": {
@@ -11872,11 +11302,11 @@
           "dev": true
         },
         "socks": {
-          "version": "2.8.7",
+          "version": "2.8.8",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip-address": "^10.0.1",
+            "ip-address": ">=10.1.1",
             "smart-buffer": "^4.2.0"
           }
         },
@@ -11888,26 +11318,6 @@
             "agent-base": "^7.1.2",
             "debug": "^4.3.4",
             "socks": "^2.8.3"
-          }
-        },
-        "spdx-correct": {
-          "version": "3.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
-          },
-          "dependencies": {
-            "spdx-expression-parse": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-              }
-            }
           }
         },
         "spdx-exceptions": {
@@ -11930,56 +11340,20 @@
           "dev": true
         },
         "ssri": {
-          "version": "12.0.0",
+          "version": "13.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "minipass": "^7.0.3"
           }
         },
-        "string-width": {
-          "version": "4.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "string-width-cjs": {
-          "version": "npm:string-width@4.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "strip-ansi-cjs": {
-          "version": "npm:strip-ansi@6.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
         "supports-color": {
-          "version": "9.4.0",
+          "version": "10.2.2",
           "bundled": true,
           "dev": true
         },
         "tar": {
-          "version": "7.5.11",
+          "version": "7.5.13",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11996,17 +11370,29 @@
           "dev": true
         },
         "tiny-relative-date": {
-          "version": "1.3.0",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true
         },
         "tinyglobby": {
-          "version": "0.2.15",
+          "version": "0.2.16",
           "bundled": true,
           "dev": true,
           "requires": {
             "fdir": "^6.5.0",
-            "picomatch": "^2.3.2"
+            "picomatch": ">=4.0.4"
+          },
+          "dependencies": {
+            "fdir": {
+              "version": "6.5.0",
+              "bundled": true,
+              "dev": true
+            },
+            "picomatch": {
+              "version": "4.0.4",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "treeverse": {
@@ -12015,158 +11401,48 @@
           "dev": true
         },
         "tuf-js": {
-          "version": "3.1.0",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@tufjs/models": "3.0.1",
-            "debug": "^4.4.1",
-            "make-fetch-happen": "^14.0.3"
-          },
-          "dependencies": {
-            "@tufjs/models": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@tufjs/canonical-json": "2.0.0",
-                "minimatch": "^9.0.5"
-              }
-            }
+            "@tufjs/models": "4.1.0",
+            "debug": "^4.4.3",
+            "make-fetch-happen": "^15.0.1"
           }
         },
-        "unique-filename": {
-          "version": "4.0.0",
+        "undici": {
+          "version": "6.25.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "unique-slug": "^5.0.0"
-          }
-        },
-        "unique-slug": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "imurmurhash": "^0.1.4"
-          }
+          "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
-        "validate-npm-package-license": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
-          },
-          "dependencies": {
-            "spdx-expression-parse": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-              }
-            }
-          }
-        },
         "validate-npm-package-name": {
-          "version": "6.0.2",
+          "version": "7.0.2",
           "bundled": true,
           "dev": true
         },
         "walk-up-path": {
-          "version": "3.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
         "which": {
-          "version": "5.0.0",
+          "version": "6.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "^3.1.1"
-          },
-          "dependencies": {
-            "isexe": {
-              "version": "3.1.5",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "wrap-ansi": {
-          "version": "8.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^6.1.0",
-            "string-width": "^5.0.1",
-            "strip-ansi": "^7.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "6.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "emoji-regex": {
-              "version": "9.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "7.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^6.2.2"
-              }
-            }
-          }
-        },
-        "wrap-ansi-cjs": {
-          "version": "npm:wrap-ansi@7.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            }
+            "isexe": "^4.0.0"
           }
         },
         "write-file-atomic": {
-          "version": "6.0.0",
+          "version": "7.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "imurmurhash": "^0.1.4",
             "signal-exit": "^4.0.1"
           }
         },
@@ -12359,6 +11635,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true
     },
     "pify": {
@@ -12698,7 +11980,7 @@
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
         "@semantic-release/github": "^11.0.0",
-        "@semantic-release/npm": "^12.0.2",
+        "@semantic-release/npm": ">=13.0.0",
         "@semantic-release/release-notes-generator": "^14.0.0-beta.1",
         "aggregate-error": "^5.0.0",
         "cosmiconfig": "^9.0.0",
@@ -13047,7 +12329,7 @@
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.0.1",
+            "fast-uri": ">=3.1.2",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -13059,6 +12341,12 @@
           "dev": true
         }
       }
+    },
+    "tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true
     },
     "temp-dir": {
       "version": "3.0.0",
@@ -13138,15 +12426,7 @@
       "dev": true,
       "requires": {
         "fdir": "^6.5.0",
-        "picomatch": "^2.3.2"
-      },
-      "dependencies": {
-        "picomatch": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-          "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-          "dev": true
-        }
+        "picomatch": ">=4.0.4"
       }
     },
     "to-regex-range": {
@@ -13207,6 +12487,12 @@
         "tslib": "^1.8.1"
       }
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -13234,6 +12520,12 @@
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
       "optional": true
+    },
+    "undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true
     },
     "unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,15 @@
   "overrides": {
     "handlebars": "^4.7.9",
     "picomatch": "^2.3.2",
+    "tinyglobby": {
+      "picomatch": ">=4.0.4"
+    },
     "flatted": "^3.4.2",
     "glob-promise": "^6.0.7",
-    "lodash": "4.18.1"
+    "lodash": "4.18.1",
+    "fast-uri": ">=3.1.2",
+    "ip-address": ">=10.1.1",
+    "@semantic-release/npm": ">=13.0.0"
   },
   "devDependencies": {
     "@as-pect/cli": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
     "handlebars": "^4.7.9",
     "picomatch": "^2.3.2",
     "tinyglobby": {
-      "picomatch": "^4.0.4"
+      "picomatch": "4.0.4"
     },
     "flatted": "^3.4.2",
     "glob-promise": "^6.0.7",
     "lodash": "4.18.1",
-    "fast-uri": "^3.1.2",
-    "ip-address": "^10.1.1",
-    "@semantic-release/npm": "^13.0.0"
+    "fast-uri": "3.1.2",
+    "ip-address": "10.1.1",
+    "@semantic-release/npm": "13.1.5"
   },
   "devDependencies": {
     "@as-pect/cli": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
     "handlebars": "^4.7.9",
     "picomatch": "^2.3.2",
     "tinyglobby": {
-      "picomatch": ">=4.0.4"
+      "picomatch": "^4.0.4"
     },
     "flatted": "^3.4.2",
     "glob-promise": "^6.0.7",
     "lodash": "4.18.1",
-    "fast-uri": ">=3.1.2",
-    "ip-address": ">=10.1.1",
-    "@semantic-release/npm": ">=13.0.0"
+    "fast-uri": "^3.1.2",
+    "ip-address": "^10.1.1",
+    "@semantic-release/npm": "^13.0.0"
   },
   "devDependencies": {
     "@as-pect/cli": "^8.0.1",


### PR DESCRIPTION
## Summary

- Bumped fast-uri to 3.1.2 to resolve high severity vulnerabilities (alerts #115, #116)
- Bumped ip-address to 10.1.1 to resolve medium severity vulnerability (alert #114)
- Bumped picomatch to 4.0.4 to resolve medium severity vulnerability (alert #113)
- Bumped `@semantic-release/npm` to >=13.1.5 to satisfy engine requirements and pull in patched npm@11 bundled deps
- Pinned Node.js to 22.14.x in CI workflows to satisfy `@semantic-release/npm@13.1.5` engine requirement

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #115, #116 | `fast-uri` | **high** | Bumped to 3.1.2 via override |
| #114 | `ip-address` | **medium** | Bumped to 10.1.1 via override |
| #113 | `picomatch` | **medium** | Bumped to 4.0.4 via override |