### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3814,9 +3814,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.14.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
-      "integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -3895,8 +3895,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.5.0",
-        "@npmcli/config": "^10.9.0",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -3914,46 +3914,46 @@
         "fs-minipass": "^3.0.3",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
+        "hosted-git-info": "^9.0.3",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.7",
-        "libnpmexec": "^10.2.7",
-        "libnpmfund": "^7.0.21",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.7",
-        "libnpmpublish": "^11.1.3",
+        "libnpmpack": "^9.1.11",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.5",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
         "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.3.0",
+        "node-gyp": "^12.4.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.5.0",
+        "pacote": "^21.5.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.13",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -4026,7 +4026,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4042,7 +4042,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.5.0",
+      "version": "9.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4090,7 +4090,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.9.0",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4284,7 +4284,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.2.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -4332,13 +4332,13 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -4407,7 +4407,7 @@
       }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4435,7 +4435,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4628,7 +4628,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4727,7 +4727,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.1",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4809,12 +4809,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.7",
+      "version": "8.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -4828,13 +4828,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.7",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -4851,12 +4851,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.21",
+      "version": "7.0.25",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.5.0"
+        "@npmcli/arborist": "^9.9.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4876,12 +4876,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.7",
+      "version": "9.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -4891,7 +4891,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.3",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4935,7 +4935,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4951,7 +4951,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.3.5",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -4960,7 +4960,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.5",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5126,7 +5126,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.3.0",
+      "version": "12.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5250,13 +5250,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -5303,7 +5303,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.5.0",
+      "version": "21.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5364,7 +5364,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5461,7 +5461,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5485,17 +5485,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.1.0",
-        "@sigstore/tuf": "^4.0.1",
-        "@sigstore/verify": "^3.1.0"
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -5512,7 +5512,7 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.8",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5586,7 +5586,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.13",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -5614,7 +5614,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5682,7 +5682,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.25.0",
+      "version": "6.27.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7294,9 +7294,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7575,7 +7575,7 @@
       "dev": true,
       "requires": {
         "tunnel": "^0.0.6",
-        "undici": "^6.23.0"
+        "undici": "6.27.0"
       }
     },
     "@actions/io": {
@@ -8162,7 +8162,7 @@
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^9.0.0",
-        "npm": "^11.6.2",
+        "npm": "11.18.0",
         "rc": "^1.2.8",
         "read-pkg": "^10.0.0",
         "registry-auth-token": "^5.0.0",
@@ -10224,14 +10224,14 @@
       "dev": true
     },
     "npm": {
-      "version": "11.14.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
-      "integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.5.0",
-        "@npmcli/config": "^10.9.0",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -10249,46 +10249,46 @@
         "fs-minipass": "^3.0.3",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
+        "hosted-git-info": "^9.0.3",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.7",
-        "libnpmexec": "^10.2.7",
-        "libnpmfund": "^7.0.21",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.7",
-        "libnpmpublish": "^11.1.3",
+        "libnpmpack": "^9.1.11",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.5",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
         "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.3.0",
+        "node-gyp": "^12.4.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.5.0",
+        "pacote": "^21.5.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.13",
+        "tar": "7.5.16",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -10315,7 +10315,7 @@
           "dev": true
         },
         "@npmcli/agent": {
-          "version": "4.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10327,7 +10327,7 @@
           }
         },
         "@npmcli/arborist": {
-          "version": "9.5.0",
+          "version": "9.9.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10368,7 +10368,7 @@
           }
         },
         "@npmcli/config": {
-          "version": "10.9.0",
+          "version": "10.12.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10503,7 +10503,7 @@
           }
         },
         "@sigstore/core": {
-          "version": "3.2.0",
+          "version": "3.2.1",
           "bundled": true,
           "dev": true
         },
@@ -10519,7 +10519,7 @@
           "requires": {
             "@gar/promise-retry": "^1.0.2",
             "@sigstore/bundle": "^4.0.0",
-            "@sigstore/core": "^3.2.0",
+            "@sigstore/core": "3.2.1",
             "@sigstore/protobuf-specs": "^0.5.0",
             "make-fetch-happen": "^15.0.4",
             "proc-log": "^6.1.0"
@@ -10535,12 +10535,12 @@
           }
         },
         "@sigstore/verify": {
-          "version": "3.1.0",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "@sigstore/bundle": "^4.0.0",
-            "@sigstore/core": "^3.1.0",
+            "@sigstore/core": "3.2.1",
             "@sigstore/protobuf-specs": "^0.5.0"
           }
         },
@@ -10584,7 +10584,7 @@
           "dev": true
         },
         "bin-links": {
-          "version": "6.0.0",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10601,7 +10601,7 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.5",
+          "version": "5.0.7",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10712,7 +10712,7 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "9.0.2",
+          "version": "9.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10778,7 +10778,7 @@
           }
         },
         "ip-address": {
-          "version": "10.1.1",
+          "version": "10.2.0",
           "bundled": true,
           "dev": true
         },
@@ -10830,27 +10830,27 @@
           }
         },
         "libnpmdiff": {
-          "version": "8.1.7",
+          "version": "8.1.11",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.5.0",
+            "@npmcli/arborist": "^9.9.0",
             "@npmcli/installed-package-contents": "^4.0.0",
             "binary-extensions": "^3.0.0",
             "diff": "^8.0.2",
             "minimatch": "^10.0.3",
             "npm-package-arg": "^13.0.0",
             "pacote": "^21.0.2",
-            "tar": "^7.5.1"
+            "tar": "7.5.16"
           }
         },
         "libnpmexec": {
-          "version": "10.2.7",
+          "version": "10.3.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "@gar/promise-retry": "^1.0.0",
-            "@npmcli/arborist": "^9.5.0",
+            "@npmcli/arborist": "^9.9.0",
             "@npmcli/package-json": "^7.0.0",
             "@npmcli/run-script": "^10.0.0",
             "ci-info": "^4.0.0",
@@ -10864,11 +10864,11 @@
           }
         },
         "libnpmfund": {
-          "version": "7.0.21",
+          "version": "7.0.25",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.5.0"
+            "@npmcli/arborist": "^9.9.0"
           }
         },
         "libnpmorg": {
@@ -10881,18 +10881,18 @@
           }
         },
         "libnpmpack": {
-          "version": "9.1.7",
+          "version": "9.1.11",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^9.5.0",
+            "@npmcli/arborist": "^9.9.0",
             "@npmcli/run-script": "^10.0.0",
             "npm-package-arg": "^13.0.0",
             "pacote": "^21.0.2"
           }
         },
         "libnpmpublish": {
-          "version": "11.1.3",
+          "version": "11.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10924,7 +10924,7 @@
           }
         },
         "libnpmversion": {
-          "version": "8.0.3",
+          "version": "8.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10936,12 +10936,12 @@
           }
         },
         "lru-cache": {
-          "version": "11.3.5",
+          "version": "11.5.1",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "15.0.5",
+          "version": "15.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11054,7 +11054,7 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "12.3.0",
+          "version": "12.4.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11064,9 +11064,9 @@
             "nopt": "^9.0.0",
             "proc-log": "^6.0.0",
             "semver": "^7.3.5",
-            "tar": "^7.5.4",
+            "tar": "7.5.16",
             "tinyglobby": "^0.2.12",
-            "undici": "^6.25.0",
+            "undici": "6.27.0",
             "which": "^6.0.0"
           }
         },
@@ -11136,12 +11136,12 @@
           }
         },
         "npm-profile": {
-          "version": "12.0.1",
+          "version": "12.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "npm-registry-fetch": "^19.0.0",
-            "proc-log": "^6.0.0"
+            "proc-log": "^6.1.0"
           }
         },
         "npm-registry-fetch": {
@@ -11170,7 +11170,7 @@
           "dev": true
         },
         "pacote": {
-          "version": "21.5.0",
+          "version": "21.5.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11190,7 +11190,7 @@
             "proc-log": "^6.0.0",
             "sigstore": "^4.0.0",
             "ssri": "^13.0.0",
-            "tar": "^7.4.3"
+            "tar": "7.5.16"
           }
         },
         "parse-conflict-json": {
@@ -11213,7 +11213,7 @@
           }
         },
         "postcss-selector-parser": {
-          "version": "7.1.1",
+          "version": "7.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11274,7 +11274,7 @@
           "optional": true
         },
         "semver": {
-          "version": "7.7.4",
+          "version": "7.8.5",
           "bundled": true,
           "dev": true
         },
@@ -11284,16 +11284,16 @@
           "dev": true
         },
         "sigstore": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "@sigstore/bundle": "^4.0.0",
-            "@sigstore/core": "^3.1.0",
+            "@sigstore/core": "3.2.1",
             "@sigstore/protobuf-specs": "^0.5.0",
-            "@sigstore/sign": "^4.1.0",
-            "@sigstore/tuf": "^4.0.1",
-            "@sigstore/verify": "^3.1.0"
+            "@sigstore/sign": "^4.1.1",
+            "@sigstore/tuf": "^4.0.2",
+            "@sigstore/verify": "3.1.1"
           }
         },
         "smart-buffer": {
@@ -11302,7 +11302,7 @@
           "dev": true
         },
         "socks": {
-          "version": "2.8.8",
+          "version": "2.8.9",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11353,7 +11353,7 @@
           "dev": true
         },
         "tar": {
-          "version": "7.5.13",
+          "version": "7.5.19",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11375,7 +11375,7 @@
           "dev": true
         },
         "tinyglobby": {
-          "version": "0.2.16",
+          "version": "0.2.17",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11411,7 +11411,7 @@
           }
         },
         "undici": {
-          "version": "6.25.0",
+          "version": "6.27.0",
           "bundled": true,
           "dev": true
         },
@@ -12522,9 +12522,9 @@
       "optional": true
     },
     "undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true
     },
     "unicode-emoji-modifier-base": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,12 @@
     "lodash": "4.18.1",
     "fast-uri": "3.1.2",
     "ip-address": "10.1.1",
-    "@semantic-release/npm": "13.1.5"
+    "@semantic-release/npm": "13.1.5",
+    "npm": "11.18.0",
+    "@sigstore/verify": "3.1.1",
+    "@sigstore/core": "3.2.1",
+    "undici": "6.27.0",
+    "tar": "7.5.16"
   },
   "devDependencies": {
     "@as-pect/cli": "^8.0.1",


### PR DESCRIPTION
## Summary

- Resolved 6 open Dependabot security alerts by upgrading npm (via override) to 11.18.0, which bundles patched versions of all affected transitive dependencies

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #118 | `tar` | **medium** | Bundled via npm@11.18.0 (7.5.13 -> 7.5.19) |
| #120 | `undici` | **medium** | Bundled via npm@11.18.0 (6.25.0 -> 6.27.0) |
| #121 | `undici` | **low** | Bundled via npm@11.18.0 (6.25.0 -> 6.27.0) |
| #122 | `undici` | **low** | Bundled via npm@11.18.0 (6.25.0 -> 6.27.0) |
| #124 | `@sigstore/core` | **medium** | Bundled via npm@11.18.0 (3.2.0 -> 3.2.1) |
| #125 | `@sigstore/verify` | **medium** | Bundled via npm@11.18.0 (3.1.0 -> 3.1.1) |

## Notes

All 6 vulnerable packages were bundled inside `npm@11.14.1` (which is a dependency of `@semantic-release/npm@13.1.5`). Standard `overrides` entries cannot reach into npm's bundled dependencies. Overriding npm itself to 11.18.0 causes npm to install a newer version of itself with all the patched bundled packages.