### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1860,10 +1860,20 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2557,9 +2567,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -3291,9 +3301,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7886,7 +7896,7 @@
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.0",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -8839,7 +8849,7 @@
       "requires": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.2.0",
         "parse-json": "^5.2.0"
       },
       "dependencies": {
@@ -8850,9 +8860,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-          "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+          "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"
@@ -9122,7 +9132,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -9340,9 +9350,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true
     },
     "fastq": {
@@ -9834,9 +9844,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -12329,7 +12339,7 @@
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "3.1.2",
+            "fast-uri": "3.1.4",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }

--- a/package.json
+++ b/package.json
@@ -37,14 +37,18 @@
     "flatted": "^3.4.2",
     "glob-promise": "^6.0.7",
     "lodash": "4.18.1",
-    "fast-uri": "3.1.2",
+    "fast-uri": "3.1.4",
     "ip-address": "10.1.1",
     "@semantic-release/npm": "13.1.5",
     "npm": "11.18.0",
     "@sigstore/verify": "3.1.1",
     "@sigstore/core": "3.2.1",
     "undici": "6.27.0",
-    "tar": "7.5.16"
+    "tar": "7.5.16",
+    "js-yaml": "^3.15.0",
+    "cosmiconfig": {
+      "js-yaml": "^4.2.0"
+    }
   },
   "devDependencies": {
     "@as-pect/cli": "^8.0.1",


### PR DESCRIPTION
## Summary

- Resolved 4 open Dependabot security alerts by bumping vulnerable transitive dependencies via npm `overrides`

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #130 | `fast-uri` | **high** | Bumped override to 3.1.4 |
| #129 | `fast-uri` | **high** | Bumped override to 3.1.4 |
| #128 | `js-yaml` | **medium** | Added override pinning to ^3.15.0 |
| #127 | `js-yaml` | **medium** | Added nested override for the `js-yaml` dependency of `cosmiconfig` pinning it to ^4.2.0 |