### PR TITLE
fix: run workflows on Node 24

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 22.14.x
+          node-version: 24.x
       - run: npm ci --legacy-peer-deps
       - run: npm run asbuild
       # Run benchmark with `go test -bench` and stores the output to a file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 22.14.x
+          node-version: 24.x
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.14.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
## Summary

- Update test, release, and benchmark workflows to run project commands on Node 24.x.
- Align the configured runtime with the Node 24 action updates from #29.

## Validation

- npm test